### PR TITLE
[RAC-6591] Release both version number and snapshot tagged packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+// Copyright © 2018 DELL Inc. or its subsidiaries.  All Rights Reserved.
+
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.sonarqube'
@@ -60,6 +62,11 @@ javadoc {
     options {
          encoding = 'windows-1251'
     }
+}
+
+task snapshotJar(type: Jar){
+    baseName =  archivesBaseName
+    version = '1.0-SNAPSHOT'
 }
 
 task sourcesJar(type: Jar) {
@@ -153,7 +160,7 @@ uploadArchives {
 }
 
 artifacts {
-    archives javadocJar, sourcesJar
+    archives javadocJar, sourcesJar, snapshotJar
 }
 
 signing {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'signing'
 apply plugin: 'maven'
 //apply plugin: 'nebula.lint'
+apply plugin: 'io.codearte.nexus-staging'
 
 sourceCompatibility = 1.8
 version = "${version}"
@@ -30,6 +31,7 @@ buildscript {
        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
        //classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
+       classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0"
   }
 }
 


### PR DESCRIPTION
**Background**
After the transition of SMI CI/CD from Bamboo to concourse, current process only release snapshot tagged package. This PR changed the gradle build script, to support releasing both 1.0-snapshot and version number tagged packages.

**Reviewer**
@yaolingling @lanchongyizu